### PR TITLE
Fix team data not created during v3-v4 data migration

### DIFF
--- a/src/data-migrations/v3/migrateToRepos.ts
+++ b/src/data-migrations/v3/migrateToRepos.ts
@@ -104,6 +104,7 @@ export function migrateToRepos() {
         weaponPresetIds: [],
         name: `${loadout.name} team`,
       };
+      newTeamPresetRepo.push(newTeamPreset);
 
       // The `weapons` field was added to the DTO code later, but the data was never amended, so there is a chance the user data does not have it
       const weapons =
@@ -245,8 +246,6 @@ export function migrateToRepos() {
             newTeamPreset.weaponPresetIds.push(newWeaponPreset.id);
           }
         });
-
-        newTeamPresetRepo.push(newTeamPreset);
       }
 
       // Migrate gear set


### PR DESCRIPTION
Fix a case in v3-v4-migration where an (empty) team object isn't added to the repo but referenced in a character preset. Happens when the old loadout team doesn't have weapons

### 🛠 Changes being made

### 🏎 Checklist

- [x] Checked if the changelog needs updating
