### PR TITLE
Attack stat name was changed from Attack to ATK in-game

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tof-tools",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/definitions/stat-types.ts
+++ b/src/definitions/stat-types.ts
@@ -122,7 +122,7 @@ export const statTypesLookup: Data<StatTypeId, StatType> = {
       id: "Attack",
       displayName: "Attack",
       shortDisplayName: "ATK",
-      inGameName: "Attack",
+      inGameName: "ATK",
       role: "Attack",
       elementalType: "All",
       isPercentageBased: false,

--- a/src/features/changelog/changelog.tsx
+++ b/src/features/changelog/changelog.tsx
@@ -333,4 +333,11 @@ export const changelog: Changelog = [
       </>
     ),
   },
+  {
+    semver: "4.4.1",
+    date: new Date(Date.UTC(2025, 2, 10)),
+    title: "Fixed import gear using screenshot",
+    description:
+      "Fixed Attack stat not being imported properly because the stat name was changed from 'Attack' to 'ATK' in-game",
+  },
 ];


### PR DESCRIPTION
### 🛠 Changes being made
Fixes gear OCR for attack stat

### 🏎 Checklist

- [x] Checked if the changelog needs updating
