### PR TITLE
Remove hard-coded order arrays for definitions. Fixes some missed simulacrum traits

### DIFF
--- a/src/definitions/matrices/matrix-definitions.ts
+++ b/src/definitions/matrices/matrix-definitions.ts
@@ -1,6 +1,6 @@
-import type { Data } from "../../models/data";
+import { sortAlphabetically } from "../../utils/locale-utils";
 import { keysOf } from "../../utils/object-utils";
-import type { SimulacrumId } from "../simulacra/simulacrum-id";
+import { simulacrumIds } from "../simulacra/simulacrum-id";
 import { mapToFullBuffAbilityDefinition } from "../types/buff/partial-buff-ability-definition";
 import type { MatrixBuffAbilityDefinition } from "../types/matrix/matrix-buff-ability-definition";
 import type { MatrixDefinition } from "../types/matrix/matrix-definition";
@@ -60,133 +60,77 @@ import { yanuo } from "./definitions/yanuo";
 import { yuLan } from "./definitions/yu-lan";
 import { zero } from "./definitions/zero";
 
-export type MatrixDefinitionId = SimulacrumId | "Haboela" | "Scylla";
+const matrixDefinitionIds = [...simulacrumIds, "Haboela", "Scylla"] as const;
+
+export type MatrixDefinitionId = (typeof matrixDefinitionIds)[number];
 
 // Hard-coded defined matrix definitions. Partial for ease-of-input
-const partialMatrixDefinitions: Data<
+const partialMatrixDefinitions: Record<
   MatrixDefinitionId,
   PartialMatrixDefinition
 > = {
-  allIds: [
-    "Alyss",
-    "Anka",
-    "Annabella",
-    "Antoria",
-    "Asuka",
-    "Asurada",
-    "Brevey",
-    "Carrot",
-    "Claudia",
-    "Claudia Storm Eye",
-    "Cobalt-B",
-    "Cocoritter",
-    "Crow",
-    "Fei Se",
-    "Fenrir",
-    "Fiona",
-    "Frigg",
-    "Gnonno",
-    "Gray Fox",
-    "Haboela",
-    "Huang (Mimi)",
-    "Huma",
-    "Icarus",
-    "Ji Yu",
-    "King",
-    "Lan",
-    "Lin",
-    "Ling Han",
-    "Liu Huo",
-    "Lyncis",
-    "Lyra",
-    "Meryl",
-    "Meryl Ironheart",
-    "Ming Jing",
-    "Nan Yin",
-    "Nemesis",
-    "Nemesis Voidpiercer",
-    "Nola",
-    "Plotti",
-    "Rei",
-    "Roslyn",
-    "Rubilia",
-    "Ruby",
-    "Saki Fuwa",
-    "Samir",
-    "Scylla",
-    "Shiro",
-    "Tian Lang",
-    "Tsubasa",
-    "Umi",
-    "Yan Miao",
-    "Yanuo",
-    "Yu Lan",
-    "Zero",
-  ],
-  byId: {
-    Alyss: alyss,
-    Anka: anka,
-    Annabella: annabella,
-    Antoria: antoria,
-    Asuka: asuka,
-    Asurada: asurada,
-    Brevey: brevey,
-    Carrot: carrot,
-    Claudia: claudia,
-    "Claudia Storm Eye": claudiaStormEye,
-    "Cobalt-B": cobaltB,
-    Cocoritter: cocoritter,
-    Crow: crow,
-    "Fei Se": feiSe,
-    Fenrir: fenrir,
-    Fiona: fiona,
-    Frigg: frigg,
-    Gnonno: gnonno,
-    "Gray Fox": grayFox,
-    Haboela: haboela,
-    "Huang (Mimi)": mimi,
-    Huma: huma,
-    Icarus: icarus,
-    "Ji Yu": jiYu,
-    King: king,
-    Lan: lan,
-    Lin: lin,
-    "Ling Han": lingHan,
-    "Liu Huo": liuHuo,
-    Lyncis: lyncis,
-    Lyra: lyra,
-    Meryl: meryl,
-    "Meryl Ironheart": merylIronheart,
-    "Ming Jing": mingJing,
-    "Nan Yin": nanYin,
-    Nemesis: nemesis,
-    "Nemesis Voidpiercer": nemesisVoidpiercer,
-    Nola: nola,
-    Plotti: plotti,
-    Rei: rei,
-    Roslyn: roslyn,
-    Rubilia: rubilia,
-    Ruby: ruby,
-    "Saki Fuwa": sakiFuwa,
-    Samir: samir,
-    Scylla: scylla,
-    Shiro: shiro,
-    "Tian Lang": tianLang,
-    Tsubasa: tsubasa,
-    Umi: umi,
-    "Yan Miao": yanMiao,
-    Yanuo: yanuo,
-    "Yu Lan": yuLan,
-    Zero: zero,
-  },
+  Alyss: alyss,
+  Anka: anka,
+  Annabella: annabella,
+  Antoria: antoria,
+  Asuka: asuka,
+  Asurada: asurada,
+  Brevey: brevey,
+  Carrot: carrot,
+  Claudia: claudia,
+  "Claudia Storm Eye": claudiaStormEye,
+  "Cobalt-B": cobaltB,
+  Cocoritter: cocoritter,
+  Crow: crow,
+  "Fei Se": feiSe,
+  Fenrir: fenrir,
+  Fiona: fiona,
+  Frigg: frigg,
+  Gnonno: gnonno,
+  "Gray Fox": grayFox,
+  Haboela: haboela,
+  "Huang (Mimi)": mimi,
+  Huma: huma,
+  Icarus: icarus,
+  "Ji Yu": jiYu,
+  King: king,
+  Lan: lan,
+  Lin: lin,
+  "Ling Han": lingHan,
+  "Liu Huo": liuHuo,
+  Lyncis: lyncis,
+  Lyra: lyra,
+  Meryl: meryl,
+  "Meryl Ironheart": merylIronheart,
+  "Ming Jing": mingJing,
+  "Nan Yin": nanYin,
+  Nemesis: nemesis,
+  "Nemesis Voidpiercer": nemesisVoidpiercer,
+  Nola: nola,
+  Plotti: plotti,
+  Rei: rei,
+  Roslyn: roslyn,
+  Rubilia: rubilia,
+  Ruby: ruby,
+  "Saki Fuwa": sakiFuwa,
+  Samir: samir,
+  Scylla: scylla,
+  Shiro: shiro,
+  "Tian Lang": tianLang,
+  Tsubasa: tsubasa,
+  Umi: umi,
+  "Yan Miao": yanMiao,
+  Yanuo: yanuo,
+  "Yu Lan": yuLan,
+  Zero: zero,
 };
 
 // Map full matrix definitions by using the partial definitions and defaults
 const fullMatrixDefinitions: Partial<
   Record<MatrixDefinitionId, MatrixDefinition>
 > = {};
-keysOf(partialMatrixDefinitions.byId).forEach((id) => {
-  const partialDefinition = partialMatrixDefinitions.byId[id];
+keysOf(partialMatrixDefinitions).forEach((id) => {
+  const partialDefinition = partialMatrixDefinitions[id];
 
   fullMatrixDefinitions[id] = {
     ...partialDefinition,
@@ -207,5 +151,7 @@ export function getMatrixDefinition(id: MatrixDefinitionId): MatrixDefinition {
 }
 
 export function getAllMatrixDefinitions() {
-  return partialMatrixDefinitions.allIds.map((id) => getMatrixDefinition(id));
+  return matrixDefinitionIds
+    .toSorted(sortAlphabetically) // This may need to sort by displayName instead if localization is ever added
+    .map((id) => getMatrixDefinition(id));
 }

--- a/src/definitions/simulacra/simulacrum-id.ts
+++ b/src/definitions/simulacra/simulacrum-id.ts
@@ -1,53 +1,56 @@
-export type SimulacrumId =
-  | "Alyss"
-  | "Anka"
-  | "Annabella"
-  | "Antoria"
-  | "Asuka"
-  | "Asurada"
-  | "Brevey"
-  | "Carrot"
-  | "Claudia"
-  | "Claudia Storm Eye"
-  | "Cobalt-B"
-  | "Cocoritter"
-  | "Crow"
-  | "Fei Se"
-  | "Fenrir"
-  | "Fiona"
-  | "Frigg"
-  | "Gnonno"
-  | "Gray Fox"
-  | "Huang (Mimi)"
-  | "Huma"
-  | "Icarus"
-  | "Ji Yu"
-  | "King"
-  | "Lan"
-  | "Lin"
-  | "Ling Han"
-  | "Liu Huo"
-  | "Lyncis"
-  | "Lyra"
-  | "Meryl"
-  | "Meryl Ironheart"
-  | "Ming Jing"
-  | "Nan Yin"
-  | "Nemesis"
-  | "Nemesis Voidpiercer"
-  | "Nola"
-  | "Plotti"
-  | "Rei"
-  | "Roslyn"
-  | "Rubilia"
-  | "Ruby"
-  | "Saki Fuwa"
-  | "Samir"
-  | "Shiro"
-  | "Tian Lang"
-  | "Tsubasa"
-  | "Umi"
-  | "Yan Miao"
-  | "Yanuo"
-  | "Yu Lan"
-  | "Zero";
+export const simulacrumIds = [
+  "Alyss",
+  "Anka",
+  "Annabella",
+  "Antoria",
+  "Asuka",
+  "Asurada",
+  "Brevey",
+  "Carrot",
+  "Claudia",
+  "Claudia Storm Eye",
+  "Cobalt-B",
+  "Cocoritter",
+  "Crow",
+  "Fei Se",
+  "Fenrir",
+  "Fiona",
+  "Frigg",
+  "Gnonno",
+  "Gray Fox",
+  "Huang (Mimi)",
+  "Huma",
+  "Icarus",
+  "Ji Yu",
+  "King",
+  "Lan",
+  "Lin",
+  "Ling Han",
+  "Liu Huo",
+  "Lyncis",
+  "Lyra",
+  "Meryl",
+  "Meryl Ironheart",
+  "Ming Jing",
+  "Nan Yin",
+  "Nemesis",
+  "Nemesis Voidpiercer",
+  "Nola",
+  "Plotti",
+  "Rei",
+  "Roslyn",
+  "Rubilia",
+  "Ruby",
+  "Saki Fuwa",
+  "Samir",
+  "Shiro",
+  "Tian Lang",
+  "Tsubasa",
+  "Umi",
+  "Yan Miao",
+  "Yanuo",
+  "Yu Lan",
+  "Zero",
+] as const;
+
+export type SimulacrumId = (typeof simulacrumIds)[number];

--- a/src/definitions/simulacra/simulacrum-traits.ts
+++ b/src/definitions/simulacra/simulacrum-traits.ts
@@ -1,8 +1,8 @@
-import type { Data } from "../../models/data";
 import type {
   SimulacrumTrait,
   SimulacrumTraitId,
 } from "../../models/simulacrum-trait";
+import { sortAlphabetically } from "../../utils/locale-utils";
 import { keysOf } from "../../utils/object-utils";
 import type { BuffAbilityDefinition } from "../types/buff/buff-ability-definition";
 import { mapToFullBuffAbilityDefinition } from "../types/buff/partial-buff-ability-definition";
@@ -59,124 +59,73 @@ import { yanMiao } from "./definitions/yan-miao";
 import { yanuo } from "./definitions/yanuo";
 import { yuLan } from "./definitions/yu-lan";
 import { zero } from "./definitions/zero";
+import { simulacrumIds } from "./simulacrum-id";
 
 // Hard-coded defined simulacrum trait definitions. Partial for ease-of-input
-const partialSimulacrumTraits: Data<SimulacrumTraitId, PartialSimulacrumTrait> =
-  {
-    allIds: [
-      "Alyss",
-      "Anka",
-      "Annabella",
-      "Asuka",
-      "Asurada",
-      "Brevey",
-      "Carrot",
-      "Claudia",
-      "Claudia Storm Eye",
-      "Cobalt-B",
-      "Cocoritter",
-      "Crow",
-      "Fei Se",
-      "Fenrir",
-      "Fiona",
-      "Frigg",
-      "Gnonno",
-      "Gray Fox",
-      "Huang (Mimi)",
-      "Huma",
-      "Icarus",
-      "King",
-      "Lan",
-      "Lin",
-      "Ling Han",
-      "Liu Huo",
-      "Lyncis",
-      "Lyra",
-      "Meryl",
-      "Meryl Ironheart",
-      "Ming Jing",
-      "Nan Yin",
-      "Nemesis",
-      "Nemesis Voidpiercer",
-      "Nola",
-      "Plotti",
-      "Rei",
-      "Roslyn",
-      "Rubilia",
-      "Ruby",
-      "Saki Fuwa",
-      "Samir",
-      "Shiro",
-      "Tian Lang",
-      "Tsubasa",
-      "Umi",
-      "Yan Miao",
-      "Yanuo",
-      "Yu Lan",
-      "Zero",
-    ],
-    byId: {
-      Alyss: alyss,
-      Anka: anka,
-      Annabella: annabella,
-      Antoria: antoria,
-      Asuka: asuka,
-      Asurada: asurada,
-      Brevey: brevey,
-      Carrot: carrot,
-      Claudia: claudia,
-      "Claudia Storm Eye": claudiaStormEye,
-      "Cobalt-B": cobaltB,
-      Cocoritter: cocoritter,
-      Crow: crow,
-      "Fei Se": feiSe,
-      Fenrir: fenrir,
-      Fiona: fiona,
-      Frigg: frigg,
-      Gnonno: gnonno,
-      "Gray Fox": grayFox,
-      "Huang (Mimi)": mimi,
-      Huma: huma,
-      Icarus: icarus,
-      "Ji Yu": jiYu,
-      King: king,
-      Lan: lan,
-      Lin: lin,
-      "Ling Han": lingHan,
-      "Liu Huo": liuHuo,
-      Lyncis: lyncis,
-      Lyra: lyra,
-      Meryl: meryl,
-      "Meryl Ironheart": merylIronheart,
-      "Ming Jing": mingJing,
-      "Nan Yin": nanYin,
-      Nemesis: nemesis,
-      "Nemesis Voidpiercer": nemesisVoidpiercer,
-      Nola: nola,
-      Plotti: plotti,
-      Rei: rei,
-      Roslyn: roslyn,
-      Rubilia: rubilia,
-      Ruby: ruby,
-      "Saki Fuwa": sakiFuwa,
-      Samir: samir,
-      Shiro: shiro,
-      "Tian Lang": tianLang,
-      Tsubasa: tsubasa,
-      Umi: umi,
-      "Yan Miao": yanMiao,
-      Yanuo: yanuo,
-      "Yu Lan": yuLan,
-      Zero: zero,
-    },
-  };
+const partialSimulacrumTraits: Record<
+  SimulacrumTraitId,
+  PartialSimulacrumTrait
+> = {
+  Alyss: alyss,
+  Anka: anka,
+  Annabella: annabella,
+  Antoria: antoria,
+  Asuka: asuka,
+  Asurada: asurada,
+  Brevey: brevey,
+  Carrot: carrot,
+  Claudia: claudia,
+  "Claudia Storm Eye": claudiaStormEye,
+  "Cobalt-B": cobaltB,
+  Cocoritter: cocoritter,
+  Crow: crow,
+  "Fei Se": feiSe,
+  Fenrir: fenrir,
+  Fiona: fiona,
+  Frigg: frigg,
+  Gnonno: gnonno,
+  "Gray Fox": grayFox,
+  "Huang (Mimi)": mimi,
+  Huma: huma,
+  Icarus: icarus,
+  "Ji Yu": jiYu,
+  King: king,
+  Lan: lan,
+  Lin: lin,
+  "Ling Han": lingHan,
+  "Liu Huo": liuHuo,
+  Lyncis: lyncis,
+  Lyra: lyra,
+  Meryl: meryl,
+  "Meryl Ironheart": merylIronheart,
+  "Ming Jing": mingJing,
+  "Nan Yin": nanYin,
+  Nemesis: nemesis,
+  "Nemesis Voidpiercer": nemesisVoidpiercer,
+  Nola: nola,
+  Plotti: plotti,
+  Rei: rei,
+  Roslyn: roslyn,
+  Rubilia: rubilia,
+  Ruby: ruby,
+  "Saki Fuwa": sakiFuwa,
+  Samir: samir,
+  Shiro: shiro,
+  "Tian Lang": tianLang,
+  Tsubasa: tsubasa,
+  Umi: umi,
+  "Yan Miao": yanMiao,
+  Yanuo: yanuo,
+  "Yu Lan": yuLan,
+  Zero: zero,
+};
 
 // Map full simulacrum traits by using the partial definitions and defaults
 const fullSimulacrumTraits: Partial<
   Record<SimulacrumTraitId, SimulacrumTrait>
 > = {};
-keysOf(partialSimulacrumTraits.byId).forEach((id) => {
-  const partialDefinition = partialSimulacrumTraits.byId[id];
+keysOf(partialSimulacrumTraits).forEach((id) => {
+  const partialDefinition = partialSimulacrumTraits[id];
 
   fullSimulacrumTraits[id] = {
     ...partialDefinition,
@@ -194,5 +143,7 @@ export function getSimulacrumTrait(id: SimulacrumTraitId): SimulacrumTrait {
 }
 
 export function getAllSimulacrumTraits() {
-  return partialSimulacrumTraits.allIds.map((id) => getSimulacrumTrait(id));
+  return simulacrumIds
+    .toSorted(sortAlphabetically) // This may need to sort by displayName instead if localization is ever added
+    .map((id) => getSimulacrumTrait(id));
 }

--- a/src/definitions/weapons/weapon-definitions.ts
+++ b/src/definitions/weapons/weapon-definitions.ts
@@ -1,6 +1,6 @@
-import type { Data } from "../../models/data";
+import { sortAlphabetically } from "../../utils/locale-utils";
 import { keysOf } from "../../utils/object-utils";
-import type { SimulacrumId } from "../simulacra/simulacrum-id";
+import { simulacrumIds } from "../simulacra/simulacrum-id";
 import { mapToFullBuffAbilityDefinition } from "../types/buff/partial-buff-ability-definition";
 import type { PartialWeaponDefinition } from "../types/weapon/partial-weapon-definition";
 import type { WeaponBuffAbilityDefinition } from "../types/weapon/weapon-buff-ability-definition";
@@ -68,158 +68,97 @@ import { yanuo } from "./definitions/yanuo";
 import { yuLan } from "./definitions/yu-lan";
 import { zero } from "./definitions/zero";
 
-export type WeaponDefinitionId =
-  | SimulacrumId
-  | "Nemesis Voidpiercer (Altered)"
-  | "Nemesis Voidpiercer (Flame-Physical)"
-  | "Nemesis Voidpiercer (Frost-Volt)"
-  | "Nemesis Voidpiercer (Physical-Flame)"
-  | "Nemesis Voidpiercer (Volt-Frost)"
-  | "Nola (Altered)"
-  | "Nola (Flame-Physical)"
-  | "Nola (Frost-Volt)"
-  | "Nola (Physical-Flame)"
-  | "Nola (Volt-Frost)";
+const weaponDefinitionIds = [
+  ...simulacrumIds,
+  "Nemesis Voidpiercer (Altered)",
+  "Nemesis Voidpiercer (Flame-Physical)",
+  "Nemesis Voidpiercer (Frost-Volt)",
+  "Nemesis Voidpiercer (Physical-Flame)",
+  "Nemesis Voidpiercer (Volt-Frost)",
+  "Nola (Altered)",
+  "Nola (Flame-Physical)",
+  "Nola (Frost-Volt)",
+  "Nola (Physical-Flame)",
+  "Nola (Volt-Frost)",
+] as const;
+
+export type WeaponDefinitionId = (typeof weaponDefinitionIds)[number];
 
 // Hard-coded defined weapon definitions. Partial for ease-of-input
-const partialWeaponDefinitions: Data<
+const partialWeaponDefinitions: Record<
   WeaponDefinitionId,
   PartialWeaponDefinition
 > = {
-  allIds: [
-    "Alyss",
-    "Anka",
-    "Annabella",
-    "Antoria",
-    "Asuka",
-    "Asurada",
-    "Brevey",
-    "Carrot",
-    "Claudia",
-    "Claudia Storm Eye",
-    "Cobalt-B",
-    "Cocoritter",
-    "Crow",
-    "Fei Se",
-    "Fenrir",
-    "Fiona",
-    "Frigg",
-    "Gnonno",
-    "Gray Fox",
-    "Huang (Mimi)",
-    "Huma",
-    "Icarus",
-    "Ji Yu",
-    "King",
-    "Lan",
-    "Lin",
-    "Ling Han",
-    "Liu Huo",
-    "Lyncis",
-    "Lyra",
-    "Meryl",
-    "Meryl Ironheart",
-    "Ming Jing",
-    "Nan Yin",
-    "Nemesis",
-    "Nemesis Voidpiercer (Altered)",
-    "Nemesis Voidpiercer (Flame-Physical)",
-    "Nemesis Voidpiercer (Frost-Volt)",
-    "Nemesis Voidpiercer (Physical-Flame)",
-    "Nemesis Voidpiercer (Volt-Frost)",
-    "Nola (Altered)",
-    "Nola (Flame-Physical)",
-    "Nola (Frost-Volt)",
-    "Nola (Physical-Flame)",
-    "Nola (Volt-Frost)",
-    "Plotti",
-    "Rei",
-    "Roslyn",
-    "Rubilia",
-    "Ruby",
-    "Saki Fuwa",
-    "Samir",
-    "Shiro",
-    "Tian Lang",
-    "Tsubasa",
-    "Umi",
-    "Yan Miao",
-    "Yanuo",
-    "Yu Lan",
-    "Zero",
-  ],
-  byId: {
-    Alyss: alyss,
-    Anka: anka,
-    Annabella: annabella,
-    Antoria: antoria,
-    Asuka: asuka,
-    Asurada: asurada,
-    Brevey: brevey,
-    Carrot: carrot,
-    Claudia: claudia,
-    "Claudia Storm Eye": claudiaStormEye,
-    "Cobalt-B": cobaltB,
-    Cocoritter: cocoritter,
-    Crow: crow,
-    "Fei Se": feiSe,
-    Fenrir: fenrir,
-    Fiona: fiona,
-    Frigg: frigg,
-    Gnonno: gnonno,
-    "Gray Fox": grayFox,
-    "Huang (Mimi)": mimi,
-    Huma: huma,
-    Icarus: icarus,
-    "Ji Yu": jiYu,
-    King: king,
-    Lan: lan,
-    Lin: lin,
-    "Ling Han": lingHan,
-    "Liu Huo": liuHuo,
-    Lyncis: lyncis,
-    Lyra: lyra,
-    Meryl: meryl,
-    "Meryl Ironheart": merylIronheart,
-    "Ming Jing": mingJing,
-    "Nan Yin": nanYin,
-    Nemesis: nemesis,
-    "Nemesis Voidpiercer": nemesisVoidpiercerBase,
-    "Nemesis Voidpiercer (Altered)": nemesisVoidpiercerAltered,
-    "Nemesis Voidpiercer (Flame-Physical)": nemesisVoidpiercerFlamePhysical,
-    "Nemesis Voidpiercer (Frost-Volt)": nemesisVoidpiercerFrostVolt,
-    "Nemesis Voidpiercer (Physical-Flame)": nemesisVoidpiercerPhysicalFlame,
-    "Nemesis Voidpiercer (Volt-Frost)": nemesisVoidpiercerVoltFrost,
-    Nola: nolaBase,
-    "Nola (Altered)": nolaAltered,
-    "Nola (Flame-Physical)": nolaFlamePhysical,
-    "Nola (Frost-Volt)": nolaFrostVolt,
-    "Nola (Physical-Flame)": nolaPhysicalFlame,
-    "Nola (Volt-Frost)": nolaVoltFrost,
-    Plotti: plotti,
-    Rei: rei,
-    Roslyn: roslyn,
-    Rubilia: rubilia,
-    Ruby: ruby,
-    "Saki Fuwa": sakiFuwa,
-    Samir: samir,
-    Shiro: shiro,
-    "Tian Lang": tianLang,
-    Tsubasa: tsubasa,
-    Umi: umi,
-    "Yan Miao": yanMiao,
-    Yanuo: yanuo,
-    "Yu Lan": yuLan,
-    Zero: zero,
-  },
+  Alyss: alyss,
+  Anka: anka,
+  Annabella: annabella,
+  Antoria: antoria,
+  Asuka: asuka,
+  Asurada: asurada,
+  Brevey: brevey,
+  Carrot: carrot,
+  Claudia: claudia,
+  "Claudia Storm Eye": claudiaStormEye,
+  "Cobalt-B": cobaltB,
+  Cocoritter: cocoritter,
+  Crow: crow,
+  "Fei Se": feiSe,
+  Fenrir: fenrir,
+  Fiona: fiona,
+  Frigg: frigg,
+  Gnonno: gnonno,
+  "Gray Fox": grayFox,
+  "Huang (Mimi)": mimi,
+  Huma: huma,
+  Icarus: icarus,
+  "Ji Yu": jiYu,
+  King: king,
+  Lan: lan,
+  Lin: lin,
+  "Ling Han": lingHan,
+  "Liu Huo": liuHuo,
+  Lyncis: lyncis,
+  Lyra: lyra,
+  Meryl: meryl,
+  "Meryl Ironheart": merylIronheart,
+  "Ming Jing": mingJing,
+  "Nan Yin": nanYin,
+  Nemesis: nemesis,
+  "Nemesis Voidpiercer": nemesisVoidpiercerBase,
+  "Nemesis Voidpiercer (Altered)": nemesisVoidpiercerAltered,
+  "Nemesis Voidpiercer (Flame-Physical)": nemesisVoidpiercerFlamePhysical,
+  "Nemesis Voidpiercer (Frost-Volt)": nemesisVoidpiercerFrostVolt,
+  "Nemesis Voidpiercer (Physical-Flame)": nemesisVoidpiercerPhysicalFlame,
+  "Nemesis Voidpiercer (Volt-Frost)": nemesisVoidpiercerVoltFrost,
+  Nola: nolaBase,
+  "Nola (Altered)": nolaAltered,
+  "Nola (Flame-Physical)": nolaFlamePhysical,
+  "Nola (Frost-Volt)": nolaFrostVolt,
+  "Nola (Physical-Flame)": nolaPhysicalFlame,
+  "Nola (Volt-Frost)": nolaVoltFrost,
+  Plotti: plotti,
+  Rei: rei,
+  Roslyn: roslyn,
+  Rubilia: rubilia,
+  Ruby: ruby,
+  "Saki Fuwa": sakiFuwa,
+  Samir: samir,
+  Shiro: shiro,
+  "Tian Lang": tianLang,
+  Tsubasa: tsubasa,
+  Umi: umi,
+  "Yan Miao": yanMiao,
+  Yanuo: yanuo,
+  "Yu Lan": yuLan,
+  Zero: zero,
 };
 
 // Map full weapon definitions by using the partial definitions and defaults
 const fullWeaponDefinitions: Partial<
   Record<WeaponDefinitionId, WeaponDefinition>
 > = {};
-keysOf(partialWeaponDefinitions.byId).forEach((id) => {
-  const partialDefinition = partialWeaponDefinitions.byId[id];
+keysOf(partialWeaponDefinitions).forEach((id) => {
+  const partialDefinition = partialWeaponDefinitions[id];
 
   fullWeaponDefinitions[id] = {
     ...partialDefinition,
@@ -239,5 +178,7 @@ export function getWeaponDefinition(id: WeaponDefinitionId): WeaponDefinition {
 }
 
 export function getAllWeaponDefinitions() {
-  return partialWeaponDefinitions.allIds.map((id) => getWeaponDefinition(id));
+  return weaponDefinitionIds
+    .toSorted(sortAlphabetically) // This may need to sort by displayName instead if localization is ever added
+    .map((id) => getWeaponDefinition(id));
 }

--- a/src/utils/locale-utils.ts
+++ b/src/utils/locale-utils.ts
@@ -18,3 +18,6 @@ export function toShortNumberFormat(number: number) {
   });
   return formatter.format(number);
 }
+
+/** Sorting function two sort two strings alphabetically. For use in Array sort() etc. */
+export const sortAlphabetically = (a: string, b: string) => a.localeCompare(b);


### PR DESCRIPTION
### 🛠 Changes being made
Instead of a hard-coded array to enforce the order for definitions (weapons, matrices & traits), the order is derived from a single point of truth (`simulacrumTraitIds` from `simulacrumIds`; `weaponDefinitionIds` from `simulacrumIds` with some additions; `matrixDefinitionIds` from `simulacrumIds` with some additions), then sorted alphabetically.

This eliminates the chance of forgetting to add a new Id to the order array when adding a new weapon, matrix, trait etc.

This fixes missing Antoria and Ji Yu traits.

### 🏎 Checklist

- [x] Checked if the changelog needs updating
